### PR TITLE
deps: Bump superstring to Pulsar's fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mkdirp": "^0.5.1",
     "pathwatcher": "^8.1.0",
     "serializable": "^1.0.3",
-    "superstring": "^2.4.4",
+    "superstring": "https://github.com/pulsar-edit/superstring/archive/c2ff062317362363eae7d392cd78aef4fcc8b9f8.tar.gz",
     "underscore-plus": "^1.0.0",
     "winattr": "^3.0.0"
   },


### PR DESCRIPTION
Should help with building against newer NodeJS (18.x)

Context:

The `master` branch of our fork of superstring just has some slight changes to get it compiling on newer NodeJS/Electron, if I understand correctly.

It still uses `nan`, rather than jumping to other solutions like `node-api` (AKA `n-api`) or WASM.

This is for helping us get to a point where Pulsar is bootstrappable from a system with NodeJS 18 on it, rather than requiring us to hold back to NodeJS 16 to get Pulsar bootstrapped. (Unrelated to the "NodeJS version" Pulsar will actually use in production -- that is based on what's baked in to the Electron version we use. This is just about initially building our dependencies when we do `yarn install`, strictly as a quirk of our bootstrap process before we rebuild the dependencies for Electron.)

THIS IS A DRAFT WHILE I TEST OUT IF BUMPING THIS IN PULSAR CORE WOULD BASICALLY WORK, OR HAVE ANY ISSUES. IF IT'S NOT FIT FOR CORE, THEN THERE'S NO POINT COMMITTING IT TO THIS REPO'S MASTER BRANCH. PLEASE DON'T MERGE THIS AT THE MOMENT, THANKS.