### PR TITLE
Fix incorrect `isInConflict` logic

### DIFF
--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -408,6 +408,13 @@ describe('TextBuffer IO', () => {
         expect(buffer.isInConflict()).toBe(true)
         await buffer.save()
         expect(buffer.isInConflict()).toBe(false)
+        // Ensure we don't get flipped into conflicted status after the
+        // `onDidChange` handler comes through…
+        await wait(1000)
+        expect(buffer.isInConflict()).toBe(false)
+        buffer.setText('q')
+        // …and the buffer is modified again.
+        expect(buffer.isInConflict()).toBe(false)
         done()
       })
     })

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -2273,9 +2273,20 @@ class TextBuffer {
         if (this.isModified()) {
           const source = this.file.getPath()
           if (!(await this.buffer.baseTextMatchesFile(source, this.getEncoding()))) {
+            // Emit `did-conflict` and take no other action. We will keep the
+            // current buffer contents so that the user's changes are not lost.
             this.emitter.emit('did-conflict')
+          } else {
+            // Despite being modified, we're once again in alignment with what
+            // is on disk. This file is not in conflict.
+            this.fileHasChangedSinceLastLoad = false
           }
         } else {
+          // This buffer was previously in sync with what was on disk, so we
+          // can update its contents to match the new contents on disk. By
+          // definition, this means there is no conflict, so we'll reset the
+          // appropriate flag.
+          this.fileHasChangedSinceLastLoad = false
           return this.load({internal: true})
         }
       }, this.fileChangeDelay)))


### PR DESCRIPTION
This is a blocker for [pulsar#1478](https://github.com/pulsar-edit/pulsar/pull/1478), which I'd tentatively targeted for version 1.132.0. So it's not a drop-everything-and-review sort of thing, but I'd appreciate if someone took a look at this after we ship 1.131.2.

Buffer conflict happens when

* A buffer is backed by a file on disk
* The user makes changes locally that are not yet committed
* Some other program changes the contents of the file on disk.

If the buffer were unmodified, we'd simply swap in the new contents of the buffer. But when there are pending buffer changes, we can't do that without losing the user's work. Hence the buffer is now in conflict. We have an `isInConflict` method that returns a boolean, plus an `onDidConflict` method that notifies when the buffer enters a conflicted state.

The logic of `isInConflict` is simple:

```js
  isInConflict () {
    return this.isModified() && this.fileHasChangedSinceLastLoad
  }
```

`fileHasChangedSinceLastLoad` is flipped to `true` whenever we detect a filesystem change for the buffer's file. It should flip to `false` whenever we load from disk and do something with the contents — or whenever we write to disk, since that guarantees synchronization between the buffer contents and the disk contents.

### How it should work

This is a bit esoteric, but imagine this scenario:

* You open a `TextBuffer` backed by a file on disk
* You make some changes locally that are not yet committed
* Some other program changes the contents of the file on disk
* We notice that the file's contents changed, and that they are incompatible with the user's changes; we emit a `did-conflict` event, and set a flag (`fileHasChangedSinceLastLoad`) to `true` to mark the file as conflicted
* The `isInConflict` method will thereafter return `true`, as it will whenever (a) `fileHasChangedSinceLastLoad` is `true` and (b) `isModified()` returns `true`

Once you save the file again, `fileHasChangedSinceLastLoaded` is reset to `false`, since that serves to synchronize the buffer contents and the file contents. Even if you modify the buffer again after saving, `isInConflict` will correctly return `false`, since `fileHasChangedSinceLastLoaded` is still `false`.

### How it actually works

But here's a scenario that slipped through the specs:

* You open a `TextBuffer` backed by a file on disk
* You make some changes locally, then save the file
* Soon after, we detect the file has changed on disk (never mind that we're the ones who changed it!)
* `fileHasChangedSinceLastLoad` flips to `true` even though the file isn't actually in conflict (and `did-conflict` was not emitted)
* Once you modify the buffer again, both halves of the `isInConflict` method's test are now `true`, and the buffer is treated as being in conflict even though it isn't

I think the _idea_ was that the other code paths through the `onDidChange` handler were _eventually_ supposed to result in `fileHasChangedSinceLastLoaded` flipping back to `false`… but in practice, we take one of the side doors instead, and return early before the line in `finishLoading` that actually resets the flag.

In practice, the changes in [pulsar#1478](https://github.com/pulsar-edit/pulsar/pull/1478) cause the new “this file is in conflict; are you sure you want to save?” dialog to fire _much_ too often… because `isInConflict` is incorrectly returning `true` practically all the time after the initial save to disk.

This PR should fix this. There are probably a couple different approaches I could've taken for this, but I went with the one that I knew I could reason about correctly: in the code paths in `onDidChange` where we _know_ the buffer contents are synchronized with what's on disk, we'll proactively flip` fileHasChangedSinceLastLoad` back to `false`.

### Testing

The first commit changes an existing spec to demonstrate the problem; if you check out _just_ that commit, the spec will fail.

The next commit makes the failing spec pass again.