### PR TITLE
Enhance deleted state

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "yargs": "^6.5.0"
   },
   "dependencies": {
-    "@pulsar-edit/pathwatcher": "^9.0.2",
+    "@pulsar-edit/pathwatcher": "^9.0.3",
     "@pulsar-edit/superstring": "^3.0.4",
     "delegato": "^1.0.0",
     "diff": "^2.2.1",

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -14,7 +14,7 @@ const winattr = require('winattr')
 process.on('unhandledRejection', console.error)
 
 async function wait (ms) {
-  return new Promise(r => setTimeout(r, ms));
+  return new Promise(r => setTimeout(r, ms))
 }
 
 describe('TextBuffer IO', () => {
@@ -34,7 +34,7 @@ describe('TextBuffer IO', () => {
     // `await` briefly to allow the file watcher to clean up. This is a
     // `pathwatcher` requirement that we can fix by updating its API — but
     // that's a can of worms we don't want to open yet.
-    await wait(10);
+    await wait(10)
   })
 
   describe('.load', () => {
@@ -581,8 +581,9 @@ describe('TextBuffer IO', () => {
   })
 
   describe('.isModified', () => {
+    let filePath
     beforeEach(async done => {
-      const filePath = temp.openSync('atom').path
+      filePath = temp.openSync('atom').path
       fs.writeFileSync(filePath, '')
       buffer = await TextBuffer.load(filePath)
       done()
@@ -607,9 +608,22 @@ describe('TextBuffer IO', () => {
         buffer.undo()
         buffer.undo()
         expect(buffer.isModified()).toBe(false)
+        expect(buffer.isDeleted()).toBe(false)
         await stopChangingPromise()
         expect(modifiedStatusChanges).toEqual([true, false])
         done()
+      })
+
+      describe('and the file is deleted', () => {
+        it('reports the modified status as true', async () => {
+          buffer.setText(`lorem ipsum`)
+          await buffer.save()
+          buffer.setText(`lorem ipsum dolor`)
+          fs.unlinkSync(filePath)
+          await wait(500)
+          expect(buffer.isModified()).toBe(true)
+          expect(buffer.isDeleted()).toBe(true)
+        })
       })
     })
 
@@ -627,6 +641,54 @@ describe('TextBuffer IO', () => {
         expect(modifiedStatusChanges).toEqual([false])
         done()
       })
+
+      describe('and the file is deleted', () => {
+        it('reports the modified status as false', async () => {
+          buffer.setText(`lorem ipsum`)
+          await buffer.save()
+          fs.unlinkSync(filePath)
+          await wait(500)
+          expect(buffer.isModified()).toBe(false)
+          expect(buffer.isDeleted()).toBe(true)
+        })
+
+        it('initially reports the modified status as false, but flips it back to true if the user makes further changes', async () => {
+          buffer.setText(`lorem ipsum`)
+          await buffer.save()
+          fs.unlinkSync(filePath)
+          await wait(500)
+          expect(buffer.isModified()).toBe(false)
+          expect(buffer.isDeleted()).toBe(true)
+
+          buffer.insert([0, 0], '! ')
+          expect(buffer.isModified()).toBe(true)
+          expect(buffer.isDeleted()).toBe(true)
+
+          // `isModified` should return `true` even if we revert the buffer's
+          // contents to what they were at the time of deletion.
+          buffer.setText(`lorem ipsum`)
+          expect(buffer.isModified()).toBe(true)
+          expect(buffer.isDeleted()).toBe(true)
+        })
+
+        describe('and re-saved', () => {
+          it('results in isModified and isDeleted no longer returning true', async () => {
+            buffer.setText(`lorem ipsum`)
+            await buffer.save()
+            fs.unlinkSync(filePath)
+            await wait(500)
+            buffer.insert([0, 0], '! ')
+            expect(buffer.isModified()).toBe(true)
+            expect(buffer.isDeleted()).toBe(true)
+
+            await buffer.saveAs(filePath)
+
+            expect(buffer.isModified()).toBe(false)
+            expect(buffer.isDeleted()).toBe(false)
+          })
+        })
+      })
+
     })
 
     describe('when the buffer is reloaded', () => {
@@ -1087,7 +1149,18 @@ describe('TextBuffer IO', () => {
           fs.removeSync(filePath)
           buffer.file.onDidDelete(() => {
             expect(buffer.getPath()).toBe(filePath)
-            expect(buffer.isModified()).toBeTruthy()
+            // `buffer.isModified` used to report `true` automatically whenever
+            // a buffer does not have a backing file. Now it depends on whether
+            // the file ever existed – and, if so, whether the buffer was in a
+            // modified state when the file was deleted.
+            //
+            // The narrow exception we're carving out is one where the file
+            // contents were in sync with the buffer contents at the moment of
+            // file deletion. If so, its `isModified=false` status will persist
+            // until even one edit is made, at which point it will flip back to
+            // `isModified=true` until the buffer is destroyed or once again
+            // saved to disk.
+            expect(buffer.isModified()).toBeFalsy()
             done()
           })
         })

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -455,11 +455,15 @@ describe('TextBuffer IO', () => {
         // Modify the file after the save has been asynchronously initiated
         buffer.onDidSave(() => buffer.append('!'))
 
-        const subscription = buffer.file.onDidChange(() => setTimeout(() => {
-          subscription.dispose()
-          expect(events.length).toBe(0)
-          done()
-        }, buffer.fileChangeDelay))
+        let subscription
+        let handler = () => {
+          setTimeout(() => {
+            subscription?.dispose()
+            expect(events.length).toBe(0)
+            done()
+          }, buffer.fileChangeDelay)
+        }
+        buffer.file.onDidChange(handler)
       })
     })
 
@@ -691,6 +695,55 @@ describe('TextBuffer IO', () => {
 
     })
 
+    describe('when the buffer’s file is deleted', () => {
+      it('does not report `isModified` as `true` unless the buffer was modified at time of deletion', async () => {
+        expect(buffer.isModified()).toBe(false)
+        fs.unlinkSync(filePath)
+        await wait(500)
+        expect(buffer.isDeleted()).toBe(true)
+        expect(buffer.isModified()).toBe(false)
+
+        await wait(500)
+        await buffer.save()
+        expect(buffer.isDeleted()).toBe(false)
+        expect(buffer.isModified()).toBe(false)
+
+        buffer.insert([0, 0], 'hi')
+        expect(buffer.isModified()).toBe(true)
+        fs.unlinkSync(filePath)
+        await wait(500)
+        expect(buffer.isDeleted()).toBe(true)
+        expect(buffer.isModified()).toBe(true)
+      })
+    })
+
+    describe('when the buffer is re-saved after deletion', () => {
+      it('stops reporting the file as deleted or modified', async done => {
+        buffer.insert([0, 0], 'hi')
+        expect(buffer.isModified()).toBe(true)
+
+        fs.unlinkSync(filePath)
+        await wait(500)
+        expect(buffer.isDeleted()).toBe(true)
+        expect(buffer.isModified()).toBe(true)
+
+        await wait(500)
+
+        await buffer.save()
+        expect(buffer.isDeleted()).toBe(false)
+        expect(buffer.isModified()).toBe(false)
+
+        buffer.insert([0, 0], 'hi')
+        await wait(500)
+        fs.unlinkSync(filePath)
+        await wait(500)
+        expect(buffer.isDeleted()).toBe(true)
+        expect(buffer.isModified()).toBe(true)
+        done()
+      })
+
+    })
+
     describe('when the buffer is reloaded', () => {
       it('reports the modified status changing to false', done => {
         const modifiedStatusChanges = []
@@ -905,14 +958,17 @@ describe('TextBuffer IO', () => {
     })
 
     it('emits a conflict event if the buffer is modified and backed by a custom file', async done => {
+      fs.writeFileSync(buffer.getPath(), 'abcde')
       const file = new ReverseCaseFile(filePath)
       buffer.setFile(file)
+
+      // `ReverseCaseFile` uses `fs.watch` to set up file-watching. This
+      // built-in method is fast, but not instantaneous.
+      await wait(process.env.CI ? 500 : 200)
 
       buffer.append('f')
       expect(buffer.getText()).toBe('abcdef')
       expect(buffer.isModified()).toBe(true)
-
-      fs.writeFileSync(buffer.getPath(), '  abc')
 
       const subscription = buffer.onDidConflict(() => {
         subscription.dispose()
@@ -921,6 +977,8 @@ describe('TextBuffer IO', () => {
         expect(buffer.isInConflict()).toBe(true)
         done()
       })
+
+      fs.writeFileSync(buffer.getPath(), '  abc')
     })
 
     it('updates the buffer and its markers and notifies change observers if the buffer is unmodified', async done => {
@@ -1179,11 +1237,12 @@ describe('TextBuffer IO', () => {
       expect(fs.existsSync(buffer.getPath())).toBeTruthy()
       expect(buffer.isInConflict()).toBeFalsy()
 
-      fs.writeFileSync(filePath, 'moo')
       buffer.onDidChange(() => {
         expect(buffer.getText()).toBe('moo')
         done()
       })
+      await wait(process.env.CI ? 200 : 20)
+      fs.writeFileSync(filePath, 'moo')
     })
   })
 })

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -463,7 +463,7 @@ describe('TextBuffer IO', () => {
             done()
           }, buffer.fileChangeDelay)
         }
-        buffer.file.onDidChange(handler)
+        subscription = buffer.file.onDidChange(handler)
       })
     })
 

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -539,8 +539,14 @@ class TextBuffer {
       return !this.retainsUnmodifiedTraitAfterDeletion
     }
     if (this.file) {
+      // Now that all deletion cases are weeded out, the main determination is
+      // whether the native buffer reports itself as modified — but we keep the
+      // `existsSync` check just to be thorough.
       return !this.file.existsSync() || this.buffer.isModified()
     } else {
+      // A buffer that never had any backing file on disk is always considered
+      // to be modified _unless_ it is completely empty. We should not be
+      // prompting users to save untitled buffers with empty contents.
       return this.buffer.getLength() > 0
     }
   }
@@ -600,17 +606,26 @@ class TextBuffer {
   //     can be used to prevent further calls to the callback.
   setFile (file) {
     if (!this.file && !file) return
-    if (file && file.getPath() === this.getPath()) return
+    let isExistingFile = file && file.getPath() === this.getPath()
 
     this.file = file
-    if (this.file) {
-      if (typeof this.file.setEncoding === 'function') {
-        this.file.setEncoding(this.getEncoding())
-      }
-      this.subscribeToFile()
+    if (this.file && !isExistingFile) {
+      this.file.setEncoding?.(this.getEncoding())
     }
-
-    this.emitter.emit('did-change-path', this.getPath())
+    if (
+      this.shouldResubscribeIfPathMatches &&
+      this.file.getPath() === this.shouldResubscribeIfPathMatches) {
+    } {
+      this.subscribeToFile();
+      this.shouldResubscribeIfPathMatches = undefined;
+    }
+    if (!isExistingFile) {
+      // The act of setting a new file (even calling this method with
+      // `undefined`) should clear this buffer's deleted state.
+      this.didHaveFileOnDisk = false;
+      this.shouldResubscribeIfPathMatches = undefined;
+      this.emitter.emit('did-change-path', this.getPath())
+    }
   }
 
   // Public: Sets the character set encoding for this buffer.
@@ -871,7 +886,12 @@ class TextBuffer {
     if (undo != null) {
       Grim.deprecate('The `undo` option is deprecated. Call groupLastChanges() on the TextBuffer afterward instead.')
     }
-    this.retainsUnmodifiedTraitAfterDeletion = false
+    if (this.retainsUnmodifiedTraitAfterDeletion) {
+      this.retainsUnmodifiedTraitAfterDeletion = false
+      // Flipping this to `false` will result in a change to the "modified"
+      // state.
+      this.emitModifiedStatusChanged(this.isModified())
+    }
 
     if (this.transactCallDepth === 0) {
       const newRange = this.transact(() => this.setTextInRange(range, newText, {normalizeLineEndings}))
@@ -2031,7 +2051,7 @@ class TextBuffer {
   // Returns a language mode {Object} (See {TextBuffer::setLanguageMode} for its interface).
   getLanguageMode () { return this.languageMode }
 
-  // Experimental: Set the LanguageMode for this buffer.
+  // Experimental: Set the language mode for this buffer.
   //
   // * `languageMode` - an {Object} with the following methods:
   //   * `getLanguageId` - A {Function} that returns a {String} identifying the language.
@@ -2324,14 +2344,32 @@ class TextBuffer {
 
     if (this.file.onDidDelete) {
       this.fileSubscriptions.add(this.file.onDidDelete(() => {
+        // At this point, asking `isModified` of the native buffer will deliver
+        // an accurate result that does not care about whether the file still
+        // exists on disk.
         const modified = this.buffer.isModified()
         this.retainsUnmodifiedTraitAfterDeletion = !modified
         this.emitter.emit('did-delete')
+        // We want to keep the `file` property around so that the user can save
+        // this file again without having to pick a new path. But if that
+        // happens, we'll need to resubscribe to file events, despite already
+        // having subscribed the first time around.
+        //
+        // We can do this by calling `subscribeToFile` every time we call
+        // `setFile`, but that will create a lot of churn. Instead, we should
+        // keep track of this exact scenario and call `subscribeToFile` again
+        // only when we need to.
+        this.shouldResubscribeIfPathMatches = this.getPath();
         if (!modified && this.shouldDestroyOnFileDelete()) {
           return this.destroy()
         } else {
-          return this.emitModifiedStatusChanged(true)
+          return this.emitModifiedStatusChanged(this.isModified())
         }
+        // We don't set `this.file` to `null` because we still have a
+        // _theoretical_ file, even if it's no longer present on disk. In this
+        // scenario, we can re-commit the file to disk at its previous path
+        // with a simple "Save" command. If we nulled out `file`, the editor
+        // would prompt the user again about a save destination.
       }))
     }
 

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -5,7 +5,7 @@ const _ = require('underscore-plus')
 const path = require('path')
 const crypto = require('crypto')
 const mkdirp = require('mkdirp')
-const {TextBuffer: NativeTextBuffer} = require('@pulsar-edit/superstring');
+const {TextBuffer: NativeTextBuffer} = require('@pulsar-edit/superstring')
 const Point = require('./point')
 const Range = require('./range')
 const DefaultHistoryProvider = require('./default-history-provider')
@@ -313,22 +313,24 @@ class TextBuffer {
     return this.emitter.on('will-change', callback)
   }
 
-  // Public: Invoke the given callback synchronously when a transaction finishes
-  // with a list of all the changes in the transaction.
+  // Public: Invoke the given callback synchronously when a transaction
+  // finishes with a list of all the changes in the transaction.
   //
   // * `callback` {Function} to be called when a transaction in which textual
   //   changes occurred is completed.
   //   * `event` {Object} with the following keys:
-  //     * `oldRange` The smallest combined {Range} containing all of the old text.
-  //     * `newRange` The smallest combined {Range} containing all of the new text.
+  //     * `oldRange` The smallest combined {Range} containing all of the old
+  //       text.
+  //     * `newRange` The smallest combined {Range} containing all of the new
+  //       text.
   //     * `changes` {Array} of {Object}s summarizing the aggregated changes
   //       that occurred during the transaction. See *Working With Aggregated
   //       Changes* in the description of the {TextBuffer} class for details.
   //       * `oldRange` The {Range} of the deleted text in the contents of the
-  //         buffer as it existed *before* the batch of changes reported by this
-  //         event.
-  //       * `newRange`: The {Range} of the inserted text in the current contents
-  //         of the buffer.
+  //         buffer as it existed *before* the batch of changes reported by
+  //         this event.
+  //       * `newRange`: The {Range} of the inserted text in the current
+  //         contents of the buffer.
   //       * `oldText`: A {String} representing the deleted text.
   //       * `newText`: A {String} representing the inserted text.
   //
@@ -356,10 +358,10 @@ class TextBuffer {
   //       changes. See *Working With Aggregated Changes* in the description of
   //       the {TextBuffer} class for details.
   //       * `oldRange` The {Range} of the deleted text in the contents of the
-  //         buffer as it existed *before* the batch of changes reported by this
-  //         event.
-  //       * `newRange`: The {Range} of the inserted text in the current contents
-  //         of the buffer.
+  //         buffer as it existed *before* the batch of changes reported by
+  //         this event.
+  //       * `newRange`: The {Range} of the inserted text in the current
+  //         contents of the buffer.
   //       * `oldText`: A {String} representing the deleted text.
   //       * `newText`: A {String} representing the inserted text.
   //
@@ -614,18 +616,20 @@ class TextBuffer {
     if (this.file && !isExistingFile) {
       this.file.setEncoding?.(this.getEncoding())
     }
-    if (
-      this.shouldResubscribeIfPathMatches &&
+    // If the backing file is deleted, a subsequent call to `save` will
+    // re-create the file. In that scenario, even though the path matches the
+    // buffer's last path, we still need to resubscribe to file events.
+    let shouldResubscribe = this.shouldResubscribeIfPathMatches &&
       this.file.getPath() === this.shouldResubscribeIfPathMatches
-    ) {
-      this.subscribeToFile();
-      this.shouldResubscribeIfPathMatches = undefined;
+    if (shouldResubscribe || !isExistingFile) {
+      this.subscribeToFile()
+      this.shouldResubscribeIfPathMatches = undefined
     }
     if (!isExistingFile) {
       // The act of setting a new file (even calling this method with
       // `undefined`) should clear this buffer's deleted state.
-      this.didHaveFileOnDisk = false;
-      this.shouldResubscribeIfPathMatches = undefined;
+      this.didHaveFileOnDisk = false
+      this.shouldResubscribeIfPathMatches = undefined
       this.emitter.emit('did-change-path', this.getPath())
     }
   }
@@ -888,12 +892,6 @@ class TextBuffer {
     if (undo != null) {
       Grim.deprecate('The `undo` option is deprecated. Call groupLastChanges() on the TextBuffer afterward instead.')
     }
-    if (this.retainsUnmodifiedTraitAfterDeletion) {
-      this.retainsUnmodifiedTraitAfterDeletion = false
-      // Flipping this to `false` will result in a change to the "modified"
-      // state.
-      this.emitModifiedStatusChanged(this.isModified())
-    }
 
     if (this.transactCallDepth === 0) {
       const newRange = this.transact(() => this.setTextInRange(range, newText, {normalizeLineEndings}))
@@ -984,6 +982,18 @@ class TextBuffer {
 
     this.emitWillChangeEvent()
     this.buffer.setTextInRange(oldRange, newText)
+
+    if (this.retainsUnmodifiedTraitAfterDeletion) {
+      // This buffer is in the "deleted" state but _not_ the "modified" state.
+      // This happens when the buffer's backing file is deleted _and_ the
+      // buffer is not already considered to be modified at the time of
+      // deletion.
+      //
+      // But this method introduces a change to the buffer, so we'll clear the
+      // flag that is preventing `isModified` from returning `true`.
+      this.retainsUnmodifiedTraitAfterDeletion = false
+      this.emitModifiedStatusChanged(this.isModified())
+    }
 
     if (this.markerLayers) {
       for (const id in this.markerLayers) {
@@ -2361,7 +2371,7 @@ class TextBuffer {
         // `setFile`, but that will create a lot of churn. Instead, we should
         // keep track of this exact scenario and call `subscribeToFile` again
         // only when we need to.
-        this.shouldResubscribeIfPathMatches = this.getPath();
+        this.shouldResubscribeIfPathMatches = this.getPath()
         if (!modified && this.shouldDestroyOnFileDelete()) {
           return this.destroy()
         } else {

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -610,18 +610,31 @@ class TextBuffer {
   //     can be used to prevent further calls to the callback.
   setFile (file) {
     if (!this.file && !file) return
+
+    // We use this heuristic to try to help us skip potentially costly
+    // re-subscribes when nothing has meaningfully changed.
     let isExistingFile = file && file.getPath() === this.getPath()
+
+    // But there are some exceptions we should consider.
+    //
+    // If the backing file is deleted, a subsequent call to `save` will
+    // re-create the file. In that scenario, even though the path matches the
+    // buffer's last path, we still need to resubscribe to file events.
+    let shouldResubscribeAfterDeletion = this.shouldResubscribeIfPathMatches &&
+      file?.getPath() === this.shouldResubscribeIfPathMatches
+
+    // `file` is a duck-typed object, and just because two `file`s agree on
+    // their `getPath()` return value does not mean they are equivalent. Here
+    // we compare the old and new `file`s to see if they were instantiated from
+    // the same constructor; if not, we should re-subscribe.
+    let shouldResubscribeAfterNewImpl = !this.file || (file && this.file.constructor !== file.constructor)
 
     this.file = file
     if (this.file && !isExistingFile) {
       this.file.setEncoding?.(this.getEncoding())
     }
-    // If the backing file is deleted, a subsequent call to `save` will
-    // re-create the file. In that scenario, even though the path matches the
-    // buffer's last path, we still need to resubscribe to file events.
-    let shouldResubscribe = this.shouldResubscribeIfPathMatches &&
-      this.file.getPath() === this.shouldResubscribeIfPathMatches
-    if (shouldResubscribe || !isExistingFile) {
+
+    if (shouldResubscribeAfterDeletion || shouldResubscribeAfterNewImpl || !isExistingFile) {
       this.subscribeToFile()
       this.shouldResubscribeIfPathMatches = undefined
     }

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -616,8 +616,8 @@ class TextBuffer {
     }
     if (
       this.shouldResubscribeIfPathMatches &&
-      this.file.getPath() === this.shouldResubscribeIfPathMatches) {
-    } {
+      this.file.getPath() === this.shouldResubscribeIfPathMatches
+    ) {
       this.subscribeToFile();
       this.shouldResubscribeIfPathMatches = undefined;
     }

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -610,41 +610,17 @@ class TextBuffer {
   //     can be used to prevent further calls to the callback.
   setFile (file) {
     if (!this.file && !file) return
-
-    // We use this heuristic to try to help us skip potentially costly
-    // re-subscribes when nothing has meaningfully changed.
-    let isExistingFile = file && file.getPath() === this.getPath()
-
-    // But there are some exceptions we should consider.
-    //
-    // If the backing file is deleted, a subsequent call to `save` will
-    // re-create the file. In that scenario, even though the path matches the
-    // buffer's last path, we still need to resubscribe to file events.
-    let shouldResubscribeAfterDeletion = this.shouldResubscribeIfPathMatches &&
-      file?.getPath() === this.shouldResubscribeIfPathMatches
-
-    // `file` is a duck-typed object, and just because two `file`s agree on
-    // their `getPath()` return value does not mean they are equivalent. Here
-    // we compare the old and new `file`s to see if they were instantiated from
-    // the same constructor; if not, we should re-subscribe.
-    let shouldResubscribeAfterNewImpl = !this.file || (file && this.file.constructor !== file.constructor)
+    if (file === this.file) return
 
     this.file = file
-    if (this.file && !isExistingFile) {
-      this.file.setEncoding?.(this.getEncoding())
+    if (this.file) {
+      if (typeof this.file.setEncoding === 'function') {
+        this.file.setEncoding(this.getEncoding())
+      }
+      this.subscribeToFile()
     }
 
-    if (shouldResubscribeAfterDeletion || shouldResubscribeAfterNewImpl || !isExistingFile) {
-      this.subscribeToFile()
-      this.shouldResubscribeIfPathMatches = undefined
-    }
-    if (!isExistingFile) {
-      // The act of setting a new file (even calling this method with
-      // `undefined`) should clear this buffer's deleted state.
-      this.didHaveFileOnDisk = false
-      this.shouldResubscribeIfPathMatches = undefined
-      this.emitter.emit('did-change-path', this.getPath())
-    }
+    this.emitter.emit('did-change-path', this.getPath())
   }
 
   // Public: Sets the character set encoding for this buffer.
@@ -1972,8 +1948,16 @@ class TextBuffer {
   //
   // Returns a {Promise} that resolves when the save has completed.
   saveAs (filePath) {
-    if (!filePath) throw new Error("Can't save buffer with no file path")
-    return this.saveTo(new File(filePath))
+    if (!filePath) {
+      throw new Error("Can't save buffer with no file path")
+    }
+    let file
+    if (this.file?.getPath() === filePath) {
+      file = this.file
+    } else {
+      file = new File(filePath)
+    }
+    return this.saveTo(file)
   }
 
   async saveTo (file) {
@@ -2375,16 +2359,6 @@ class TextBuffer {
         const modified = this.buffer.isModified()
         this.retainsUnmodifiedTraitAfterDeletion = !modified
         this.emitter.emit('did-delete')
-        // We want to keep the `file` property around so that the user can save
-        // this file again without having to pick a new path. But if that
-        // happens, we'll need to resubscribe to file events, despite already
-        // having subscribed the first time around.
-        //
-        // We can do this by calling `subscribeToFile` every time we call
-        // `setFile`, but that will create a lot of churn. Instead, we should
-        // keep track of this exact scenario and call `subscribeToFile` again
-        // only when we need to.
-        this.shouldResubscribeIfPathMatches = this.getPath()
         if (!modified && this.shouldDestroyOnFileDelete()) {
           return this.destroy()
         } else {

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -568,7 +568,9 @@ class TextBuffer {
   //
   // Returns a {Boolean}.
   isInConflict () {
-    return this.isModified() && this.fileHasChangedSinceLastLoad
+    // Deleted files are automatically in conflict if they consider themselves
+    // modified.
+    return this.isModified() && (this.fileHasChangedSinceLastLoad || this.isDeleted())
   }
 
   // Public: Get the path of the associated file.

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -102,6 +102,15 @@ class TextBuffer {
     this.cachedHasAstral = null
     this._emittedWillChangeEvent = false
 
+    // Whether a buffer has ever had a backing file, whether or not it exists
+    // now.
+    this.didHaveFileOnDisk = false
+
+    // When a buffer's backing file is deleted while the file is unmodified,
+    // this trait flips to `true`… and then flips back to `false` if any
+    // further edits are made.
+    this.retainsUnmodifiedTraitAfterDeletion = false
+
     this.setEncoding(params.encoding)
     this.setPreferredLineEnding(params.preferredLineEnding)
 
@@ -524,6 +533,11 @@ class TextBuffer {
   //
   // Returns a {Boolean}.
   isModified () {
+    if (this.isDeleted()) {
+      // We typically consider a deleted file to be modified… unless it was
+      // unmodified at the time of deletion and has not been modified since.
+      return !this.retainsUnmodifiedTraitAfterDeletion
+    }
     if (this.file) {
       return !this.file.existsSync() || this.buffer.isModified()
     } else {
@@ -531,8 +545,20 @@ class TextBuffer {
     }
   }
 
-  // Public: Determine if the in-memory contents of the buffer conflict with the
-  // on-disk contents of its associated file.
+  // Public: Determine if the buffer is in a deleted state — meaning that it
+  // was previously backed by a file on disk, but is no longer.
+  isDeleted () {
+    let hasNoFile = !this.file || !this.file.existsSync()
+    return hasNoFile && this.didHaveFileOnDisk
+  }
+
+  // Public: Determine if the in-memory contents of the buffer conflict with
+  // the on-disk contents of its associated file.
+  //
+  // This happens if the contents of a buffer’s backing file change while the
+  // editor has uncommitted changes. Those uncommitted changes build upon a
+  // state that is now stale; if those changes were committed to disk, it could
+  // clobber the changes made by the external program.
   //
   // Returns a {Boolean}.
   isInConflict () {
@@ -845,6 +871,7 @@ class TextBuffer {
     if (undo != null) {
       Grim.deprecate('The `undo` option is deprecated. Call groupLastChanges() on the TextBuffer afterward instead.')
     }
+    this.retainsUnmodifiedTraitAfterDeletion = false
 
     if (this.transactCallDepth === 0) {
       const newRange = this.transact(() => this.setTextInRange(range, newText, {normalizeLineEndings}))
@@ -1929,6 +1956,7 @@ class TextBuffer {
 
       try {
         await this.buffer.save(destination, this.getEncoding())
+        this.didHaveFileOnDisk = true
       } catch (error) {
         if (error.code !== 'EACCES' || destination !== filePath) throw error
 
@@ -2100,6 +2128,8 @@ class TextBuffer {
     if (!options || !options.internal) {
       Grim.deprecate('The .load instance method is deprecated. Create a loaded buffer using TextBuffer.load(filePath) instead.')
     }
+
+    this.didHaveFileOnDisk = true
 
     const source = this.file instanceof File
       ? this.file.getPath()
@@ -2295,6 +2325,7 @@ class TextBuffer {
     if (this.file.onDidDelete) {
       this.fileSubscriptions.add(this.file.onDidDelete(() => {
         const modified = this.buffer.isModified()
+        this.retainsUnmodifiedTraitAfterDeletion = !modified
         this.emitter.emit('did-delete')
         if (!modified && this.shouldDestroyOnFileDelete()) {
           return this.destroy()


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

#12

### Description of the Change

This improves handling of a “deleted” buffer state as follows:

* Distinguishes it from buffers that never had a backing file on disk; `isDeleted` is now a state that can be queried just like `isModified` or `isInConflict`.
* Changes `isModified` so that it no longer automatically returns `true` if the buffer's file doesn't exist. Instead, it returns `false` if the buffer was unmodified at time of deletion, as long as no subsequent edits have been made. Otherwise, it returns `true` in all scenarios in which it would've previously returned `true`.

This allows us to get closer to VS Code's behavior with deleted files: allow the user to remove their tab (representing a file that was deleted) from the workspace without an unnecessary “are you sure?” prompt.

### Alternate Designs

#12 outlines the two possible designs. I went with the first one because it's more elegant.

### Possible Drawbacks

There could be unintended side effects of narrowing the definition of `isModified` for one specific kind of pane item. I haven't found any yet, but we should keep an eye on this.

### Verification Process

New unit tests.

### Release Notes

* [text-buffer] Enhance “deleted” state to distinguish whether the buffer was in a modified state during time of file deletion.