### PR TITLE
Fix issue where `isDeleted` incorrectly returned `true`…

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "yargs": "^6.5.0"
   },
   "dependencies": {
-    "@pulsar-edit/pathwatcher": "^9.0.3",
+    "@pulsar-edit/pathwatcher": "^9.0.4",
     "@pulsar-edit/superstring": "^3.0.4",
     "delegato": "^1.0.0",
     "diff": "^2.2.1",

--- a/spec/text-buffer-io-spec.js
+++ b/spec/text-buffer-io-spec.js
@@ -55,6 +55,7 @@ describe('TextBuffer IO', () => {
       buffer = await TextBuffer.load(filePath)
       expect(buffer.getText()).toBe('')
       expect(buffer.isModified()).toBe(true)
+      expect(buffer.isDeleted()).toBe(false)
       expect(buffer.undo()).toBe(false)
       expect(buffer.getText()).toBe('')
       done()

--- a/src/text-buffer.js
+++ b/src/text-buffer.js
@@ -2158,7 +2158,11 @@ class TextBuffer {
       Grim.deprecate('The .load instance method is deprecated. Create a loaded buffer using TextBuffer.load(filePath) instead.')
     }
 
-    this.didHaveFileOnDisk = true
+    if (this.file instanceof File) {
+      // The consumer is allowed to set a `File` instance with a path that does
+      // not currently exist on disk.
+      this.didHaveFileOnDisk = this.file.existsSync()
+    }
 
     const source = this.file instanceof File
       ? this.file.getPath()


### PR DESCRIPTION
…when a buffer is newly created and set to a path that does not yet exist on disk.

This is something I screwed up on #13. To track a buffer’s “deleted” state — meaning “is not currently backed by a file on disk, but was at one point” — we keep a `didHaveFileOnDisk` property and change it as needed.

In `TextBuffer::load`, I unconditionally set

```js
this.didHaveFileOnDisk = true
```

because I suppose I thought that the `load` method would always be loading a file from disk. But there are use cases for calling `load` when the buffer’s `file` instance is set to a nonexistent path.

```js
let someBuffer = TextBuffer.load('nonexistent.txt')
```

The above snippet creates a new buffer much the way it would if you'd simply said `new TextBuffer` — but it already knows _where_ it will save once you ask it to save itself. So in `TextBuffer::load` (called by the static `TextBuffer.load`) we must set `didHaveFileOnDisk` based on whether the file actually exists instead of assuming `true`.

Easy to modify an existing spec to do a sanity-check here.

This is why [pulsar#1588](https://github.com/pulsar-edit/pulsar/pull/1588) is still in draft; this regression caused an `autosave` spec to fail. Gotta land this fix and then bump `text-buffer` again before that PR is ready to come out of draft.